### PR TITLE
Replace path obj .remove call with .unlink

### DIFF
--- a/jlmkr.py
+++ b/jlmkr.py
@@ -81,7 +81,7 @@ def passthrough_nvidia(gpu_passthrough_nvidia, systemd_nspawn_additional_args, j
 
     if gpu_passthrough_nvidia != '1':
         # Cleanup the config file we made when passthrough was enabled
-        ld_so_conf_path.remove(missing_ok=True)
+        ld_so_conf_path.unlink(missing_ok=True)
         return
 
     try:


### PR DESCRIPTION
Hello, great project.

Stumbled in a small bug while testing it out.
The Pathlib object `ld_so_conf_path` calls an unknown `.remove` method, I think you meant to use `.unlink`:
https://docs.python.org/3/library/pathlib.html#pathlib.Path.unlink