### PR TITLE
Added alias command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Creating a jail is interactive. You'll be presented with questions which guide y
 
 After answering a few questions you should have your first jail up and running!
 
-## Create Command Alias
+### Create Command Alias
 
 Instead of having to cd and call the 'jlmkr.py' script you can utilise the native Linux command alias to essentially create a custom pseudo-command that you can call anywhere.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Creating a jail is interactive. You'll be presented with questions which guide y
 
 After answering a few questions you should have your first jail up and running!
 
+## Create Command Alias
+
+Instead of having to cd and call the 'jlmkr.py' script you can utilise the native Linux command alias to essentially create a custom pseudo-command that you can call anywhere.
+
+ ```
+alias jailmaker="/mnt/mypool/jailmaker/jlmkr.py"
+```
+This will allow you to run commands such as `jailmaker list` as a shorthand for `/mnt/mypool/jailmaker/jlmkr.py list`
+
 ### Autostart Jail on Boot
 
 In order to start a jail automatically after TrueNAS boots, run `/mnt/mypool/jailmaker/jlmkr.py start myjail` as Post Init Script with Type `Command` from the TrueNAS web interface.


### PR DESCRIPTION
Added a section to show users how to use the native linux alias command to shorthand the full path and file of /path/to/jlmkr.py to the command jailmaker