### PR TITLE
Added Full ZFS Dataset Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TrueNAS SCALE can create persistent Linux 'jails' with systemd-nspawn. This scri
 
 - Setting up the jail so it won't be lost when you update SCALE
 - Choosing a distro (Debian 12 strongly recommended, but Ubuntu, Arch Linux or Rocky Linux seem good choices too)
-- Will create a ZFS Dataset for each jail if the 'jailmaker' directory is a dataset (easy snapshotting)
+- Will create a ZFS Dataset for each jail if the `jailmaker` directory is a dataset (easy snapshotting)
 - Optional: configuring the jail so you can run Docker inside it
 - Optional: GPU passthrough (including [nvidia GPU](README.md#nvidia-gpu) with the drivers bind mounted from the host)
 - Starting the jail with your config applied
@@ -32,7 +32,9 @@ chmod +x jlmkr.py
 ./jlmkr.py install
 ```
 
-The `jlmkr.py` script (and the jails + config it creates) are now stored on the `jailmaker` dataset and will survive updates of TrueNAS SCALE. A symlink has been created so you can call `jlmkr` from anywhere (unless the boot pool is readonly, which is the default since SCALE 24.04). Additionally shell aliases have been setup, so you can still call `jlmkr` in an interactive shell (even if the symlink couldn't be created).
+The `jlmkr.py` script (and the jails + config it creates) are now stored on the `jailmaker` dataset and will survive updates of TrueNAS SCALE. If the automatically created `jails` directory is also a ZFS dataset (which is true for new users), then the `jlmkr.py` script will automatically create a new dataset for every jail created. This allows you to snapshot individual jails. For legacy users (where the `jails` directory is not a dataset) each jail will be stored in a plain directory.
+
+A symlink has been created so you can call `jlmkr` from anywhere (unless the boot pool is readonly, which is the default since SCALE 24.04). Additionally shell aliases have been setup, so you can still call `jlmkr` in an interactive shell (even if the symlink couldn't be created).
 
 After an update of TrueNAS SCALE the symlink will be lost (but the shell aliases will remain). To restore the symlink, just run `./jlmkr.py install` again or use [the `./jlmkr.py startup` command](#startup-jails-on-boot).
 
@@ -149,8 +151,6 @@ jlmkr log myjail
 ### Additional Commands
 
 Expert users may use the following additional commands to manage jails directly: `machinectl`, `systemd-nspawn`, `systemd-run`, `systemctl` and `journalctl`. The `jlmkr` script uses these commands under the hood and implements a subset of their functions. If you use them directly you will bypass any safety checks or configuration done by `jlmkr` and not everything will work in the context of TrueNAS SCALE.
-
-ZFS Datasets: It is recommended to the 'jailmaker' directory as a ZFS Dataset. This will automatically create a new dataset for every jail created. (Legacy) functionality also works as previously with directories.
 
 ## Networking
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ TrueNAS SCALE can create persistent Linux 'jails' with systemd-nspawn. This scri
 
 - Setting up the jail so it won't be lost when you update SCALE
 - Choosing a distro (Debian 12 strongly recommended, but Ubuntu, Arch Linux or Rocky Linux seem good choices too)
+- Will create a ZFS Dataset for each jail if the 'jailmaker' directory is a dataset (easy snapshotting)
 - Optional: configuring the jail so you can run Docker inside it
 - Optional: GPU passthrough (including [nvidia GPU](README.md#nvidia-gpu) with the drivers bind mounted from the host)
 - Starting the jail with your config applied
@@ -148,6 +149,8 @@ jlmkr log myjail
 ### Additional Commands
 
 Expert users may use the following additional commands to manage jails directly: `machinectl`, `systemd-nspawn`, `systemd-run`, `systemctl` and `journalctl`. The `jlmkr` script uses these commands under the hood and implements a subset of their functions. If you use them directly you will bypass any safety checks or configuration done by `jlmkr` and not everything will work in the context of TrueNAS SCALE.
+
+ZFS Datasets: It is recommended to the 'jailmaker' directory as a ZFS Dataset. This will automatically create a new dataset for every jail created. (Legacy) functionality also works as previously with directories.
 
 ## Networking
 

--- a/docs/zfsmigration.md
+++ b/docs/zfsmigration.md
@@ -1,0 +1,60 @@
+# ZFS Datasets Migration
+
+From version 1.1.4 ZFS Datasets support was added to jailmaker.
+By default starting in v1.1.4, jailmaker will create a separate dataset for each jail if possible. This allows the user to configure snapshots, rollbacks, replications etc.
+
+Jailmaker operates in dual-mode: it supports using both directories and datasets. If the 'jailmaker' directory is a dataset, it will use datasets, if it is a directory, it will use directories.
+___
+## Procedure to migrate from directories to ZFS Datasets
+
+### Stop all jails
+
+`jlmkr stop jail1`
+
+`jlmkr stop jail2`
+etc..
+
+### Move/rename the 'jailmaker' directory
+
+`mv jailmaker orig_jailmaker`
+
+### Create the ZFS datasets for jailmaker
+
+Create all the required datasets via GUI or CLI.
+
+You need to create the following datasets:
+
+`jailmaker`
+
+`jailmaker/jails`
+
+And one for each existing jail:
+
+`jailmaker/jails/jail1`
+
+`jailmaker/jails/jail2`
+etc.
+
+
+Via CLI:
+```
+zfs create mypool/jailmaker
+zfs create mypool/jailmaker/jails
+zfs create mypool/jailmaker/jails/jail1
+zfs create mypool/jailmaker/jails/jail2
+```
+
+
+### Move the existing jail data into the newly created datasets
+
+Now move all the jail data:
+
+`rsync -av orig_jailmaker/ jailmaker/`
+
+Warning! It's important that both directories have the `/` at the end to make sure contents are copied correctly. Otherwise you may end up with `jailmaker/jailmaker`
+
+### Test everything works
+
+If everything works, you should be able to use the `jlmkr` command directly. Try doing a `jlmkr list` to check if the jails are correctly recognized
+
+You can also try creating a new jail and see that the dataset is created automatically.

--- a/jlmkr.py
+++ b/jlmkr.py
@@ -4,7 +4,7 @@
 with full access to all files via bind mounts, \
 thanks to systemd-nspawn!"""
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 __disclaimer__ = """USE THIS SCRIPT AT YOUR OWN RISK!
 IT COMES WITHOUT WARRANTY AND IS NOT SUPPORTED BY IXSYSTEMS."""

--- a/jlmkr.py
+++ b/jlmkr.py
@@ -897,7 +897,7 @@ def get_mount_point(path):
 
 def get_zfs_dataset(path):
     """
-    Get ZFS dataset path
+    Get ZFS dataset path.
     """
     path = os.path.realpath(path)
     with open("/proc/mounts", "r") as f:
@@ -909,7 +909,7 @@ def get_zfs_dataset(path):
 
 def get_zfs_base_path():
     """
-    Get ZFS dataset path for jailmaker directory
+    Get ZFS dataset path for jailmaker directory.
     """
     zfs_base_path = get_zfs_dataset(SCRIPT_DIR_PATH)
     if not zfs_base_path:
@@ -920,8 +920,8 @@ def get_zfs_base_path():
 
 def create_zfs_dataset(relative_path):
     """
-    Create a ZFS Dataset
-    Receives the dataset to be created relative to the jailmaker script (e.g. "jails" or "jails/newjail")
+    Create a ZFS Dataset.
+    Receives the dataset to be created relative to the jailmaker script (e.g. "jails" or "jails/newjail").
     """
     dataset_to_create = os.path.join(get_zfs_base_path(), relative_path)
     eprint(f"Creating ZFS Dataset {dataset_to_create}")
@@ -930,8 +930,8 @@ def create_zfs_dataset(relative_path):
 
 def remove_zfs_dataset(relative_path):
     """
-    Remove a ZFS Dataset
-    Receives the dataset to be created relative to the jailmaker script (e.g. "jails/oldjail")
+    Remove a ZFS Dataset.
+    Receives the dataset to be created relative to the jailmaker script (e.g. "jails/oldjail").
     """
     dataset_to_remove = os.path.join((get_zfs_base_path()), relative_path)
     eprint(f"Removing ZFS Dataset {dataset_to_remove}")

--- a/jlmkr.py
+++ b/jlmkr.py
@@ -1300,7 +1300,7 @@ def create_jail(**kwargs):
                 create_zfs_dataset(JAILS_DIR_PATH)
             else:
                 os.makedirs(JAILS_DIR_PATH, exist_ok=True)
-                stat_chmod(JAILS_DIR_PATH, 0o700)
+            stat_chmod(JAILS_DIR_PATH, 0o700)
 
         # Creating a dataset for the jail if the jails dir is a dataset
         if get_zfs_dataset(JAILS_DIR_PATH):


### PR DESCRIPTION
New PR superseding [#113](https://github.com/Jip-Hop/jailmaker/pull/113)

Added Full ZFS Dataset Support:

- The script will now create a ZFS dataset for each jail if the 'jailmaker' directory is a ZFS dataset
- The script will create the 'jails' directory as a dataset if the 'jailmaker' directory is a ZFS dataset
- The script will now remove the ZFS dataset (including snapshots) when deleting the jail
- Dual mode: For legacy use without datasets, it will continue to work as previously
- The script now lists jails based on the config file existing rather than the directory

Tested on 23.10.2 and 24.04-RC1