### PR TITLE
Deprecate docker_compatible and gpu_passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ See [Advanced Networking](./NETWORKING.md) for more.
 
 ## Docker
 
-The `jailmaker` script won't install Docker for you, but it can setup the jail with the capabilities required to run docker. You can manually install Docker inside the jail using the [official installation guide](https://docs.docker.com/engine/install/#server) or use [convenience script](https://get.docker.com). Additionally you may use the [docker config template](./templates/docker/README.md).
+Using the [docker config template](./templates/docker/README.md) is recommended if you want to run docker inside the jail. You may of course manually install docker inside a jail. But keep in mind that you need to add `--system-call-filter='add_key keyctl bpf'` (or disable seccomp filtering). It is [not recommended to use host networking for a jail in which you run docker](https://github.com/Jip-Hop/jailmaker/issues/119). Docker needs to manage iptables rules, which it can safely do in its own networking namespace (when using [bridge or macvlan networking](./NETWORKING.md) for the jail).
 
 ## Documentation
 

--- a/templates/docker/config
+++ b/templates/docker/config
@@ -1,6 +1,8 @@
 startup=0
 gpu_passthrough_intel=1
 gpu_passthrough_nvidia=0
+# Turning off seccomp filtering improves performance at the expense of security
+seccomp=1
 
 # Use macvlan networking to provide an isolated network namespace,
 # so docker can manage firewall rules

--- a/templates/incus/config
+++ b/templates/incus/config
@@ -2,6 +2,8 @@
 startup=0
 gpu_passthrough_intel=1
 gpu_passthrough_nvidia=0
+# Turning off seccomp filtering improves performance at the expense of security
+seccomp=1
 
 # Use macvlan networking to provide an isolated network namespace,
 # so incus can manage firewall rules
@@ -9,7 +11,6 @@ gpu_passthrough_nvidia=0
 # Ensure to change eno1/br1 to the interface name you want to use
 # You may want to add additional options here, e.g. bind mounts
 # TODO: don't use --capability=all but specify only the required capabilities
-# TODO: or add and use privileged flag?
 systemd_nspawn_user_args=--network-macvlan=eno1
     --resolv-conf=bind-host
     --capability=all
@@ -63,8 +64,6 @@ systemd_run_default_args=--property=KillMode=mixed
     --property=TasksMax=infinity
     --collect
     --setenv=SYSTEMD_NSPAWN_LOCK=0
-# TODO: add below if required:
-# --property=DevicePolicy=auto
 
 systemd_nspawn_default_args=--keep-unit
     --quiet

--- a/templates/lxd/config
+++ b/templates/lxd/config
@@ -2,6 +2,8 @@
 startup=0
 gpu_passthrough_intel=1
 gpu_passthrough_nvidia=0
+# Turning off seccomp filtering improves performance at the expense of security
+seccomp=1
 
 # Use macvlan networking to provide an isolated network namespace,
 # so lxd can manage firewall rules
@@ -9,7 +11,6 @@ gpu_passthrough_nvidia=0
 # Ensure to change eno1/br1 to the interface name you want to use
 # You may want to add additional options here, e.g. bind mounts
 # TODO: don't use --capability=all but specify only the required capabilities
-# TODO: or add and use privileged flag?
 systemd_nspawn_user_args=--network-bridge=br1
     --resolv-conf=bind-host
     --capability=all
@@ -49,8 +50,6 @@ systemd_run_default_args=--property=KillMode=mixed
     --property=TasksMax=infinity
     --collect
     --setenv=SYSTEMD_NSPAWN_LOCK=0
-# TODO: add below if required:
-# --property=DevicePolicy=auto
 
 systemd_nspawn_default_args=--keep-unit
     --quiet

--- a/templates/podman/config
+++ b/templates/podman/config
@@ -1,6 +1,8 @@
 startup=0
 gpu_passthrough_intel=0
 gpu_passthrough_nvidia=0
+# Turning off seccomp filtering improves performance at the expense of security
+seccomp=1
 
 # Use macvlan networking to provide an isolated network namespace,
 # so podman can manage firewall rules


### PR DESCRIPTION
Remove --property=DeviceAllow= so it won't interfere with DevicePolicy=auto Added seccomp config option
Deprecated docker_compatible config option
Deprecated gpu_passthrough config option
Removed the docker_compatible question during interactive create
Updated readme and config templates
Closes https://github.com/Jip-Hop/jailmaker/issues/119