### PR TITLE
seccomp documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ TrueNAS SCALE can create persistent Linux 'jails' with systemd-nspawn. This scri
 Despite what the word 'jail' implies, jailmaker's intended use case is to create one or more additional filesystems to run alongside SCALE with minimal isolation. By default the root user in the jail with uid 0 is mapped to the host's uid 0. This has [obvious security implications](https://linuxcontainers.org/lxc/security/#privileged-containers). If this is not acceptable to you, you may lock down the jails by [limiting capabilities](https://manpages.debian.org/bookworm/systemd-container/systemd-nspawn.1.en.html#Security_Options) and/or using [user namespacing](https://manpages.debian.org/bookworm/systemd-container/systemd-nspawn.1.en.html#User_Namespacing_Options) or use a VM instead.
 
 ### seccomp
-Seccomp is a Linux kernel feature that restricts programs from making unauthorized system calls.  This means that there are times where a process run inside a jail will be killed with the error "Operation not permitted."  In order to find out which syscall needs to be added to the `--system-call-filter=` configuration you can use `strace`.  
+Seccomp is a Linux kernel feature that restricts programs from making unauthorized system calls.  This means that when seccomp is enabled there can be times where a process run inside a jail will be killed with the error "Operation not permitted."  In order to find out which syscall needs to be added to the `--system-call-filter=` configuration you can use `strace`.  
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TrueNAS SCALE can create persistent Linux 'jails' with systemd-nspawn. This scri
 
 Despite what the word 'jail' implies, jailmaker's intended use case is to create one or more additional filesystems to run alongside SCALE with minimal isolation. By default the root user in the jail with uid 0 is mapped to the host's uid 0. This has [obvious security implications](https://linuxcontainers.org/lxc/security/#privileged-containers). If this is not acceptable to you, you may lock down the jails by [limiting capabilities](https://manpages.debian.org/bookworm/systemd-container/systemd-nspawn.1.en.html#Security_Options) and/or using [user namespacing](https://manpages.debian.org/bookworm/systemd-container/systemd-nspawn.1.en.html#User_Namespacing_Options) or use a VM instead.
 
-### seccomp
+### Seccomp
 Seccomp is a Linux kernel feature that restricts programs from making unauthorized system calls.  This means that when seccomp is enabled there can be times where a process run inside a jail will be killed with the error "Operation not permitted."  In order to find out which syscall needs to be added to the `--system-call-filter=` configuration you can use `strace`.  
 
 For example:
@@ -39,7 +39,7 @@ write(2, "Failed to initialize PMU! (Opera"..., 52Failed to initialize PMU! (Ope
 ```
 The syscall that needs to be added to the `--system-call-filter` option in the jlmkr config in this case would be `perf_event_open`.  You may need to run strace multiple times.
 
-Seccomp is important for security, but as a last resort can be disabled by setting `seccomp=0` in the jail config
+Seccomp is important for security, but as a last resort can be disabled by setting `seccomp=0` in the jail config.
 
 ## Installation
 


### PR DESCRIPTION
added documentation on seccomp and how to find what syscalls need to be added to `--system-call-filter` when a command errors out with "Operation not Permitted"