### PR TITLE
add instructions for sourcing .bashrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ echo "alias jlmkr=\"sudo '/mnt/mypool/jailmaker/jlmkr.py'\"" > ~/.bashrc
 
 Please replace `/mnt/mypool/jailmaker/` with the actual path to where you stored `jlmkr.py`. If you're using zsh instead of bash, then you should replace `.bashrc` in the command above with `.zshrc`. If you've created the alias, you may use it instead of `./jlmkr.py`.
 
+The alias will be available the next time you load the shell, but to use the alias immediately you can `source ~/.bashrc` or `source ~/.zshrc`, as appropriate.
+
 ## Usage
 
 ### Create Jail


### PR DESCRIPTION
Previously, when a user used `./jlmkr.py install` they would be told how to source the rc to use the jlmkr alias immediately

I've added a little bit on sourcing the rc as that was missing from the alias section in the readme, and we can't assume the user knows how.

And in order to follow my guide or honeybadger's excellent [kubernetes guide](https://forums.truenas.com/t/running-a-custom-kubernetes-setup-in-a-sandbox/5313), the user will need the alias activated (so that they can use jlmkr from outside the dataset without having to type a fullpath)


