### PR TITLE
Automated testing script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,5 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
         run: |
-          sudo chown 0:0 jlmkr.py test/test.sh
-          sudo chmod +x jlmkr.py test/test.sh
-          sudo ./test/test.sh
+          sudo chown 0:0 jlmkr.py ./test/test-jlmkr
+          sudo bash ./test/test-jlmkr

--- a/test/test-jlmkr
+++ b/test/test-jlmkr
@@ -154,4 +154,3 @@ else
     echo "Stopped: $STOP"
     [[ "$STOP" = "Single Test" ]] || exit 1
 fi
-

--- a/test/test-jlmkr
+++ b/test/test-jlmkr
@@ -18,13 +18,15 @@ else
     # Full test is an option when using JAIL_TYPE
     FULL_TEST=${FULL_TEST:-0}
 fi
-if [ ! -r ${JAIL_CONFIG} ]; then
+if [ ! -r "${JAIL_CONFIG}" ]; then
     echo "Must supply a valid jail type or config path"
     exit 2
 fi
+
+# shellcheck disable=SC2034 # JAIL is used inside perform_test_suite
 JAIL="${2:-${JAIL_TYPE:?You must provide jail name (2nd arg) with a valid path to config}-test}"
 
-# STOP=0 - perform all non-blocking tests
+# STOP=0 - (default) perform all tests, in non-blocking mode 
 # STOP=l - only list and images, nothing else
 # STOP=i - interactive test, includ console-blocking waiting for input tests (edit and shell)
 STOP=${STOP:-0}
@@ -35,10 +37,11 @@ WAIT_FOR_JAIL=${WAIT_FOR_JAIL:-4s}
 
 #### Functions
 jlmkr () {
-    $SCALE_POOL_ROOT/jailmaker/jlmkr.py "${@:---help}"
+    "$SCALE_POOL_ROOT/jailmaker/jlmkr.py" "${@:---help}"
 }
 
 iterate () {
+    # shellcheck disable=SC2206 # $1 will pass multiple values, we want splitting here
     local SET=($1) DO=("${@:2}")
     local x j _x x_STATUS
 
@@ -53,7 +56,7 @@ iterate () {
 
             if [[ -n "$DELAY" ]]; then
                 echo "Waiting ${DELAY} seconds before test..."
-                sleep ${DELAY}
+                sleep "${DELAY}"
             fi
 
             set +e
@@ -70,6 +73,8 @@ iterate () {
 }
 
 perform_test_suite() {
+    # shellcheck disable=SC2016 # function relies heavily on single quotes preventing expansion
+
     if [[ "$STOP" =~ ^(0|l|i)$ ]]; then
         # Initialize REPORT with empty checkboxes - NO_EVAL=1 is important here, otherwise Status will be evaluated
         NO_EVAL=1 iterate "${REPORT[*]}" '(Jv)="🔳"'
@@ -86,11 +91,20 @@ perform_test_suite() {
         [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(restart) \
         && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL'
 
-        [[ "$STOP" =~ ^(i)$ ]] && TESTS=(edit shell) \
+        # If this is an interactive test, edit and shell will wait for input
+        [[ "$STOP" == "i" ]] && TESTS=(edit shell) \
         && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL'
 
+        # This is the non-interactive test for edit
+        [[ "$STOP" == "0" ]] && TESTS=(edit) \
+        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'EDITOR=cat jlmkr $j $JAIL'
+
+        # This is the non-interactive test for shell
+        [[ "$STOP" == "0" ]] && TESTS=(shell) \
+        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL /bin/sh -c "echo shell called successful"'
+
         [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(exec) \
-        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL /bin/sh -c "echo exec successful"'
+        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL /bin/sh -c "echo exec called successful"'
 
         [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(status) \
         && iterate "${TESTS[*]}" 'jlmkr $j $JAIL --no-pager'
@@ -112,6 +126,7 @@ perform_test_suite() {
     fi
     printf '\n\nReport for:\n\tCWD: %s\t\tJAIL_CONFIG: %s\n\n' "$(pwd)" "${JAIL_CONFIG}"
 
+    # shellcheck disable=SC2016
     NO_EVAL=1 iterate "${REPORT[*]}" 'echo "$(Jv) ${(Jv)_x:-$j}"' #printf '\"%s jlmkr %s\\n\"' '\$(Jv)' '\$j'"
 }
 
@@ -154,3 +169,4 @@ else
     echo "Stopped: $STOP"
     [[ "$STOP" = "Single Test" ]] || exit 1
 fi
+

--- a/test/test-jlmkr
+++ b/test/test-jlmkr
@@ -1,0 +1,157 @@
+#! /usr/bin/env bash
+
+# Example invokation
+# sudo SCALE_POOL_ROOT=$SCALE_POOL_ROOT $SCALE_POOL_ROOT/jailmaker/test/test-jlmkr docker
+
+set -e
+
+#### Global variables
+JAIL_TYPE="${1:?Must specify JAIL TYPE}"
+if [ -r "${JAIL_TYPE}" ]; then
+    JAIL_CONFIG="$JAIL_TYPE"
+    JAIL_TYPE=
+    # Can't perform full test with config path
+    FULL_TEST=0
+else
+    SCALE_POOL_ROOT=${SCALE_POOL_ROOT:?must be exported before you can run test suite}
+    JAIL_CONFIG="$SCALE_POOL_ROOT/jailmaker/templates/$JAIL_TYPE/config"
+    # Full test is an option when using JAIL_TYPE
+    FULL_TEST=${FULL_TEST:-0}
+fi
+if [ ! -r ${JAIL_CONFIG} ]; then
+    echo "Must supply a valid jail type or config path"
+    exit 2
+fi
+JAIL="${2:-${JAIL_TYPE:?You must provide jail name (2nd arg) with a valid path to config}-test}"
+
+# STOP=0 - perform all non-blocking tests
+# STOP=l - only list and images, nothing else
+# STOP=i - interactive test, includ console-blocking waiting for input tests (edit and shell)
+STOP=${STOP:-0}
+
+REPORT=(create edit exec images list log remove restart shell start status stop)
+
+WAIT_FOR_JAIL=${WAIT_FOR_JAIL:-4s}
+
+#### Functions
+jlmkr () {
+    $SCALE_POOL_ROOT/jailmaker/jlmkr.py "${@:---help}"
+}
+
+iterate () {
+    local SET=($1) DO=("${@:2}")
+    local x j _x x_STATUS
+
+    for j in "${SET[@]}"; do
+        for _x in "${DO[@]}"; do
+            x="${_x//\(Jv)/JLMKR_"$j"}"
+            # echo "$x" >&2
+            ${NO_EVAL:+:} eval "echo \$JLMKR_${j} \"$x\""
+            x_STATUS=✅
+            ${NO_EVAL:+:} eval "JLMKR_$j=$x_STATUS"
+            ${NO_EVAL:+:} eval "JLMKR_${j}_x=\"${x//\"/\'}\""
+
+            if [[ -n "$DELAY" ]]; then
+                echo "Waiting ${DELAY} seconds before test..."
+                sleep ${DELAY}
+            fi
+
+            set +e
+            eval "$x" || x_STATUS=$?
+            set -e
+            if [[ "$x_STATUS" != "✅" ]]; then
+                ${NO_EVAL:+:} eval "JLMKR_${j}_x=\"($x_STATUS) ${x//\"/\'}\""
+                ${NO_EVAL:+:} eval "JLMKR_$j=❌"
+                STOP=E:$x_STATUS
+                return
+            fi
+        done
+    done
+}
+
+perform_test_suite() {
+    if [[ "$STOP" =~ ^(0|l|i)$ ]]; then
+        # Initialize REPORT with empty checkboxes - NO_EVAL=1 is important here, otherwise Status will be evaluated
+        NO_EVAL=1 iterate "${REPORT[*]}" '(Jv)="🔳"'
+
+        TESTS=(list images)
+        iterate "${TESTS[*]}" 'jlmkr $j'
+
+        [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(create) \
+        && iterate "${TESTS[*]}" 'jlmkr $j --config $JAIL_CONFIG $JAIL'
+
+        [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(start) \
+        && iterate "${TESTS[*]}" 'jlmkr $j $JAIL'
+
+        [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(restart) \
+        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL'
+
+        [[ "$STOP" =~ ^(i)$ ]] && TESTS=(edit shell) \
+        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL'
+
+        [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(exec) \
+        && DELAY=$WAIT_FOR_JAIL iterate "${TESTS[*]}" 'jlmkr $j $JAIL /bin/sh -c "echo exec successful"'
+
+        [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(status) \
+        && iterate "${TESTS[*]}" 'jlmkr $j $JAIL --no-pager'
+
+        [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(log) \
+        && iterate "${TESTS[*]}" 'jlmkr $j $JAIL -n 10'
+
+        [[ "$STOP" =~ ^(0|l|i)$ ]] || echo "Had an Error. Cleanup up and stopping."
+        
+        # Always perform these cleanup steps, even if something failed
+        [[ "$STOP" != l ]] \
+        && TESTS=(stop) \
+        && iterate "${TESTS[*]}" 'jlmkr $j $JAIL' \
+
+        [[ "$STOP" != l ]] \
+        && TESTS=(remove) \
+        && iterate "${TESTS[*]}" 'jlmkr $j $JAIL <<<"$JAIL" '
+    
+    fi
+    printf '\n\nReport for:\n\tCWD: %s\t\tJAIL_CONFIG: %s\n\n' "$(pwd)" "${JAIL_CONFIG}"
+
+    NO_EVAL=1 iterate "${REPORT[*]}" 'echo "$(Jv) ${(Jv)_x:-$j}"' #printf '\"%s jlmkr %s\\n\"' '\$(Jv)' '\$j'"
+}
+
+#### Execution starts here
+
+perform_test_suite
+
+if [[ "$STOP" =~ ^(0|i)$ ]]; then
+    [[ "$FULL_TEST" == 1 ]] || STOP="Single Test"
+fi
+
+if [[ "$STOP" =~ ^(0|i)$ ]]; then
+    pushd "$SCALE_POOL_ROOT/jailmaker" > /dev/null || STOP=pushd
+    STOP=0 # The following test suite should only be run non-interactivley
+    
+    JAIL_CONFIG="./templates/$JAIL_TYPE/config"
+    perform_test_suite
+    
+    JAIL_CONFIG="templates/$JAIL_TYPE/config"
+    perform_test_suite
+    
+    JAIL_CONFIG="$SCALE_POOL_ROOT/jailmaker/$JAIL_CONFIG"
+    perform_test_suite
+
+    cd ~
+    perform_test_suite
+
+    TMP_JAIL_CFG=$(mktemp) \
+    && cp "$JAIL_CONFIG" "$TMP_JAIL_CFG" \
+    && JAIL_CONFIG="${TMP_JAIL_CFG}" perform_test_suite \
+    && rm "$TMP_JAIL_CFG" \
+    || STOP=E:temp_file
+    
+    popd > /dev/null || STOP=popd
+fi
+
+if [[ "$STOP" = 0 ]]; then
+    echo "All tests completed"
+else
+    echo "Stopped: $STOP"
+    [[ "$STOP" = "Single Test" ]] || exit 1
+fi
+

--- a/test/test-jlmkr
+++ b/test/test-jlmkr
@@ -6,6 +6,25 @@
 set -e
 
 #### Global variables
+
+if [[ -z "$JLMKR_PATH" && -n "$SCALE_POOL_ROOT" ]]; then
+    SCALE_POOL_ROOT=${SCALE_POOL_ROOT:?must be exported before you can run test suite}
+    JLMKR_PATH=${SCALE_POOL_ROOT}/jailmaker
+elif [[ -z "$JLMKR_PATH" ]]; then
+    JLMKR_PATH=${PWD:-.}
+fi
+if [[ ! -r "$JLMKR_PATH/jlmkr.py" ]]; then
+    >&2 printf "%s\n" \
+	"couldn't find jlmkr.py. Are you running from the jailmaker directory?" \
+	"If not, setup either JLMKR_PATH or SCALE_POOL_ROOT" \
+	""
+
+    >&2 printf "\tPWD: %s\n\tJLMKR_PATH: %s\n\tSCALE_POOL_ROOT: %s\n" \
+        "$PWD" "$JLMKR_PATH" "$SCALE_POOL_ROOT"
+
+    >&2 printf "\n"
+    exit 2
+fi
 JAIL_TYPE="${1}"
 if [ -n "${JAIL_TYPE}" ]; then
     if [ -r "${JAIL_TYPE}" ]; then
@@ -14,13 +33,12 @@ if [ -n "${JAIL_TYPE}" ]; then
         # Can't perform full test with config path
         FULL_TEST=0
     else
-        SCALE_POOL_ROOT=${SCALE_POOL_ROOT:?must be exported before you can run test suite}
-        JAIL_CONFIG="$SCALE_POOL_ROOT/jailmaker/templates/$JAIL_TYPE/config"
+        JAIL_CONFIG="$JLMKR_PATH/templates/$JAIL_TYPE/config"
         # Full test is an option when using JAIL_TYPE
         FULL_TEST=${FULL_TEST:-0}
     fi
     if [ ! -r "${JAIL_CONFIG}" ]; then
-        echo "Must supply a valid jail type or config path"
+        >&2 printf "Must supply a valid jail type or config path\n"
         exit 2
     fi
 fi
@@ -39,7 +57,7 @@ WAIT_FOR_JAIL=${WAIT_FOR_JAIL:-4s}
 
 #### Functions
 jlmkr () {
-    "$SCALE_POOL_ROOT/jailmaker/jlmkr.py" "${@:---help}"
+    /usr/bin/env python3 "$JLMKR_PATH/jlmkr.py" "${@:---help}"
 }
 
 iterate () {
@@ -57,7 +75,7 @@ iterate () {
             ${NO_EVAL:+:} eval "JLMKR_${j}_x=\"${x//\"/\'}\""
 
             if [[ -n "$DELAY" ]]; then
-                echo "Waiting ${DELAY} seconds before test..."
+                printf "Waiting %s seconds before test...\n" "${DELAY}"
                 sleep "${DELAY}"
             fi
 
@@ -114,7 +132,7 @@ perform_test_suite() {
         [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(log) \
         && iterate "${TESTS[*]}" 'jlmkr $j $JAIL -n 10'
 
-        [[ "$STOP" =~ ^(0|l|i)$ ]] || echo "Had an Error. Cleanup up and stopping."
+        [[ "$STOP" =~ ^(0|l|i)$ ]] || >&2 printf "Had an Error. Cleanup up and stopping.\n"
         
         # Always perform these cleanup steps, even if something failed
         [[ "$STOP" != l ]] \
@@ -129,7 +147,7 @@ perform_test_suite() {
     printf '\n\nReport for:\n\tCWD: %s\t\tJAIL_CONFIG: %s\n\n' "$(pwd)" "${JAIL_CONFIG}"
 
     # shellcheck disable=SC2016
-    NO_EVAL=1 iterate "${REPORT[*]}" 'echo "$(Jv) ${(Jv)_x:-$j}"' #printf '\"%s jlmkr %s\\n\"' '\$(Jv)' '\$j'"
+    NO_EVAL=1 iterate "${REPORT[*]}" 'echo "$(Jv) ${(Jv)_x:-$j}"'
 }
 
 #### Execution starts here
@@ -141,7 +159,7 @@ if [[ "$STOP" =~ ^(0|i)$ ]]; then
 fi
 
 if [[ "$STOP" =~ ^(0|i)$ ]]; then
-    pushd "$SCALE_POOL_ROOT/jailmaker" > /dev/null || STOP=pushd
+    pushd "$JLMKR_PATH" > /dev/null || STOP=pushd
     STOP=0 # The following test suite should only be run non-interactivley
     
     JAIL_CONFIG="./templates/$JAIL_TYPE/config"
@@ -150,7 +168,7 @@ if [[ "$STOP" =~ ^(0|i)$ ]]; then
     JAIL_CONFIG="templates/$JAIL_TYPE/config"
     perform_test_suite
     
-    JAIL_CONFIG="$SCALE_POOL_ROOT/jailmaker/$JAIL_CONFIG"
+    JAIL_CONFIG="$JLMKR_PATH/$JAIL_CONFIG"
     perform_test_suite
 
     cd ~
@@ -166,9 +184,9 @@ if [[ "$STOP" =~ ^(0|i)$ ]]; then
 fi
 
 if [[ "$STOP" = 0 ]]; then
-    echo "All tests completed"
+    printf "All tests completed\n"
 else
-    echo "Stopped: $STOP"
+    printf "Stopped: %s\n" "$STOP"
     [[ "$STOP" = "Single Test" ]] || exit 1
 fi
 

--- a/test/test-jlmkr
+++ b/test/test-jlmkr
@@ -6,25 +6,27 @@
 set -e
 
 #### Global variables
-JAIL_TYPE="${1:?Must specify JAIL TYPE}"
-if [ -r "${JAIL_TYPE}" ]; then
-    JAIL_CONFIG="$JAIL_TYPE"
-    JAIL_TYPE=
-    # Can't perform full test with config path
-    FULL_TEST=0
-else
-    SCALE_POOL_ROOT=${SCALE_POOL_ROOT:?must be exported before you can run test suite}
-    JAIL_CONFIG="$SCALE_POOL_ROOT/jailmaker/templates/$JAIL_TYPE/config"
-    # Full test is an option when using JAIL_TYPE
-    FULL_TEST=${FULL_TEST:-0}
-fi
-if [ ! -r "${JAIL_CONFIG}" ]; then
-    echo "Must supply a valid jail type or config path"
-    exit 2
+JAIL_TYPE="${1}"
+if [ -n "${JAIL_TYPE}" ]; then
+    if [ -r "${JAIL_TYPE}" ]; then
+        JAIL_CONFIG="$JAIL_TYPE"
+        JAIL_TYPE=
+        # Can't perform full test with config path
+        FULL_TEST=0
+    else
+        SCALE_POOL_ROOT=${SCALE_POOL_ROOT:?must be exported before you can run test suite}
+        JAIL_CONFIG="$SCALE_POOL_ROOT/jailmaker/templates/$JAIL_TYPE/config"
+        # Full test is an option when using JAIL_TYPE
+        FULL_TEST=${FULL_TEST:-0}
+    fi
+    if [ ! -r "${JAIL_CONFIG}" ]; then
+        echo "Must supply a valid jail type or config path"
+        exit 2
+    fi
 fi
 
 # shellcheck disable=SC2034 # JAIL is used inside perform_test_suite
-JAIL="${2:-${JAIL_TYPE:?You must provide jail name (2nd arg) with a valid path to config}-test}"
+JAIL="${2:-${JAIL_TYPE:-default}-test}"
 
 # STOP=0 - (default) perform all tests, in non-blocking mode 
 # STOP=l - only list and images, nothing else
@@ -83,7 +85,7 @@ perform_test_suite() {
         iterate "${TESTS[*]}" 'jlmkr $j'
 
         [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(create) \
-        && iterate "${TESTS[*]}" 'jlmkr $j --config $JAIL_CONFIG $JAIL'
+        && iterate "${TESTS[*]}" 'jlmkr $j ${JAIL_CONFIG:+--config} $JAIL_CONFIG $JAIL'
 
         [[ "$STOP" =~ ^(0|i)$ ]] && TESTS=(start) \
         && iterate "${TESTS[*]}" 'jlmkr $j $JAIL'


### PR DESCRIPTION
I created this script to test my changes with #210.

* automated tests related changes I've made to jlmkr: added argument that can be passed to `log` and `status` so that interactive features of `joutnalctl` could be avoided.

How the test-jlmkr bash script works is detailed in the next comment.