### PR TITLE
Add setup command and fix DNS resolution with NVIDIA GPU passthrough

### DIFF
--- a/templates/docker/config
+++ b/templates/docker/config
@@ -34,21 +34,23 @@ release=bookworm
 initial_setup=#!/usr/bin/bash
     set -euo pipefail
 
-    apt-get update && apt-get -y install ca-certificates curl
-    install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-    chmod a+r /etc/apt/keyrings/docker.asc
+    if ! command -v docker &> /dev/null; then
+        apt-get update && apt-get -y install ca-certificates curl
+        install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+        chmod a+r /etc/apt/keyrings/docker.asc
 
-    echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
-    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-    tee /etc/apt/sources.list.d/docker.list > /dev/null
-    
-    apt-get update
-    apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null
+        
+        apt-get update
+        apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    fi
     
     # The /usr/bin/nvidia-smi will be present when gpu_passthrough_nvidia=1
-    if [ -f /usr/bin/nvidia-smi ]; then
+    if [ -f /usr/bin/nvidia-smi ] && ! command -v nvidia-ctk &> /dev/null; then
         curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey -o /etc/apt/keyrings/nvidia.asc
         chmod a+r /etc/apt/keyrings/nvidia.asc
         curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \


### PR DESCRIPTION
Proposed fix for DNS resolution failure when gpu_passthrough_nvidia=1 is enabled.

**Note: This is untested code, meant as a starting point for discussion. I encountered these issues in my setup and thought this approach might help others.**

The issue was caused by mounting broad system library directories (like /usr/lib/x86_64-linux-gnu) which shadowed the jail's libc/NSS libraries, breaking name resolution.

Changes:
- Filter system library dirs from NVIDIA bind mounts to preserve jail DNS
- Add `setup` command to re-run initial_setup in existing jails
- Make docker template idempotent for safe re-execution
- Warn when NVIDIA Container Toolkit is missing in jail